### PR TITLE
Simplify usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ sudo make install
 3. Reboot for the change to take affect
 
 ## CONFIGURATION
-The file `config.h` is where you set your key bindings. This is similar to [suckless](https://suckless.org/philosophy) software. `config.h` is part of the source, so you must recompile and restart the program for any changes to take effect. Some default bindings are provided; you can add or remove them as needed.
+The file `config.h` is where you set your key bindings. This is similar to [suckless](https://suckless.org/philosophy)'s software practices. `config.h` is part of the source, so you must recompile and restart the program for any changes to take effect. Some default bindings are provided; you can add or remove them as needed.
 
 See [linux/input-event-codes.h](https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h) for a list of available key codes or use the [evtest](https://gitlab.freedesktop.org/libevdev/evtest) command to see device events printed to the terminal.
 
 ## USAGE
 ```
-hkd -d /dev/input/by-id/<device1>,/dev/input/by-id/<device2>,...
+hkd /dev/input/by-id/<device-id-1> /dev/input/by-id/<device-id-2> ...
 ```
 
 ## RELATED/SIMILAR SOFTWARE


### PR DESCRIPTION
Closes #14. Now uses a standard Unix-y syntax for supplying the device list.