### PR TITLE
Fixed keyboard crashing after halting hkd

### DIFF
--- a/hkd.c
+++ b/hkd.c
@@ -167,7 +167,6 @@ void *handle_device(void *path) {
 
 	/* cleanup */
 	libevdev_uinput_destroy(virtual_dev);
-	libevdev_grab(dev, LIBEVDEV_UNGRAB);
 	libevdev_free(dev);
 	close(fd);
 


### PR DESCRIPTION
Must say I am impressed in your keybind daemon. I built one myself but it only works in X11. Probably not the suckless way though - too many lines of code. Anyway, I wanted to help you out. The line in hkd.c's handle_device function that ungrab keyboard will result in any and all programs being unable to receive keyboard input if and when hkd is halted. Simply removing that line (libevdev_grab(dev, LIBEVDEV_UNGRAB)) will fix that issue. I have been looking to write an libevdev keybind daemon for as long as I have been looking to write a X11 and Wayland one. Your program was enlightening in how the libevdev library works. Thank you. I will probably make another keybinding daemon to operate the same as my X11 keybind daemon. That is to say the same clients that can communicate with mxkbd (my X11 keybinding daemon) will be able to use the libevdev one I have been planning on making.